### PR TITLE
Improve build

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -1,20 +1,21 @@
-use Panda::Common;
-use Panda::Builder;
 use LibraryMake;
-use Shell::Command;
 
-class Build is Panda::Builder {
+class Build {
     method build($workdir) {
-	my $makefiledir = "$workdir/src";
-	my $destdir = "$workdir/resources";
-	mkpath $destdir unless $destdir.IO.d;
-	make($makefiledir, $destdir);
-	my $lib = "libreadsecret";
-	my $so = get-vars('')<SO>;
-	my @fake = <.so .dll .dylib>.grep({$_ ne $so});
-	for @fake -> $fake {
-	    my $file = "$destdir/$lib$fake";
-	    $file.IO.spurt("fake\n");
-	}
+        my $srcdir = "$workdir/src";
+        my %vars = get-vars($workdir);
+        %vars<readsecret> = $*VM.platform-library-name('readsecret'.IO);
+        mkdir "$workdir/resources" unless "$workdir/resources".IO.e;
+        mkdir "$workdir/resources/libraries" unless "$workdir/resources/libraries".IO.e;
+        process-makefile($srcdir, %vars);
+        my $goback = $*CWD;
+        chdir($srcdir);
+        shell(%vars<MAKE>);
+        chdir($goback);
+    }
+
+    method isa($what) {
+        return True if $what.^name eq 'Panda::Builder';
+        callsame;
     }
 }

--- a/META6.json
+++ b/META6.json
@@ -2,14 +2,12 @@
   "name" : "Term::Readsecret",
   "source-url" : "git://github.com/titsuki/p6-Term-Readsecret.git",
   "perl" : "6.c",
-  "resources" : [ ],
-  "build-depends" : [ ],
+  "resources" : [ "libraries/readsecret" ],
+  "build-depends" : [ "LibraryMake" ],
   "provides" : {
     "Term::Readsecret" : "lib/Term/Readsecret.pm6"
   },
-  "depends" : [
-    "LibraryMake"
-  ],
+  "depends" : [ ],
   "description" : "A perl6 binding of readsecret ( https://github.com/dmeranda/readsecret ) for reading secrets or passwords from a command line secretly (not being displayed)",
   "test-depends" : [ ],
   "version" : "*",

--- a/lib/Term/Readsecret.pm6
+++ b/lib/Term/Readsecret.pm6
@@ -2,12 +2,8 @@ use v6;
 unit module Term::Readsecret;
 
 use NativeCall;
-use LibraryMake;
 
-my sub library {
-    my $so = get-vars('')<SO>;
-    return ~%?RESOURCES{"libreadsecret$so"};
-}
+my constant $library = %?RESOURCES<libraries/readsecret>.Str;
 
 my Int enum rsecret_error_ty (
     RSECRET_SUCCESS => 0,
@@ -31,9 +27,9 @@ class timespec is repr('CStruct') is export {
     has int64 $.tv_nsec;
 }
 
-my sub rsecret_get_secret_from_tty(CArray[int8], size_t, Str) returns int32 is native(&library) is export { * }
-my sub rsecret_get_secret_from_tty_timed(CArray[int8], size_t, Str, timespec) returns int32 is native(&library) is export { * }
-my sub rsecret_strerror(int32) returns Str is native(&library) is export { * }
+my sub rsecret_get_secret_from_tty(CArray[int8], size_t, Str) returns int32 is native($library) is export { * }
+my sub rsecret_get_secret_from_tty_timed(CArray[int8], size_t, Str, timespec) returns int32 is native($library) is export { * }
+my sub rsecret_strerror(int32) returns Str is native($library) is export { * }
 
 proto getsecret(Str:D $msg, |) { * }
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1,34 +1,8 @@
-obj = readsecret.o
-name = readsecret
-lib_a = lib$(name).a
+name = %readsecret%
 
-so_major = 1
-so_minor = 0
+all: %DESTDIR%/resources/libraries/%readsecret%
+clean:
+	rm %DESTDIR%/resources/libraries/%readsecret%
 
-CFLAGS = -pedantic -Wall $(pic) $(opt) $(dbg) $(falloc) $(pthreads)
-LDFLAGS = $(ldpthread)
-
-sys = $(shell uname -s | sed 's/MING32.*/MINGW32/')
-ifeq ($(sys), Darwin)
-	lib_so = lib$(name).dylib
-	shared = -dynamiclib
-else ifeq ($(sys), MINGW32)
-	lib_so = lib$(name).dll
-	shared = -shared -Wl,--output-def,lib$(name).def
-else
-	devname = lib$(name).so
-	soname = lib$(name).so.$(so_major)
-	lib_so = lib$(name).so.$(so_major).$(so_minor)
-	shared = -shared -Wl,-soname=$(soname)
-	pic = -fPIC
-endif
-
-all: %DESTDIR%/$(lib_a) %DESTDIR%/$(lib_so)
-
-%DESTDIR%/$(lib_a): $(obj)
-	$(AR) rcs $@ $(obj)
-
-%DESTDIR%/$(lib_so): $(obj)
-	$(CC) $(shared) -o $@ $(obj) $(LDFLAGS)
-	[ -n "%DESTDIR%/$(soname)" ] && ln -s %DESTDIR%/$(lib_so) %DESTDIR%/$(soname) || true
-	[ -n "%DESTDIR%/$(devname)" ] && ln -s %DESTDIR%/$(soname) %DESTDIR%/$(devname) || true
+%DESTDIR%/resources/libraries/%readsecret%: readsecret.c
+	%CC% -shared %CCSHARED% %CCFLAGS% readsecret.c -o %DESTDIR%/resources/libraries/%readsecret%

--- a/t/02-password.t
+++ b/t/02-password.t
@@ -1,0 +1,10 @@
+use v6;
+use Test;
+use Term::Readsecret;
+
+subtest {
+    my $timeout = timespec.new(tv_sec => 1, tv_nsec => 0);
+    throws-like { getsecret("password", $timeout) }, Exception, message => 'timeout waiting for user';
+}, 'timeout';
+
+done-testing;


### PR DESCRIPTION
This uses a more idiomatic perl6 approach to the build process. The Makefile.in is not perfect, but appears to work on on Linux (Windows/MSVC seems to be missing a header file)

Note that `resources/libraries/` will contain `libreadsecret.so`, `readsecret.dll`, etc (but only 1) based on the OS. An easy way to test the build process specifically is with `zef --debug build .`